### PR TITLE
fix: update docs and tests to reflect correct default value of S3_DIRECTORY_SYNC_DERIVE_CONTENT_TYPE and S3_DIRECTORY_SYNC_PROGRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Parameters can either be passed in the command line as arguments or as environme
   <tr>
     <td><code>S3_DIRECTORY_SYNC_DERIVE_CONTENT_TYPE</code></td>
     <td>If set to <code>true</code> will derive `Content-Type` metadata from file extension via <a href="https://www.npmjs.com/package/mime-types"><code>mime-types</code></a></td>
-    <td><code>true</code></td>
+    <td><code>false</code></td>
   </tr>
   <tr>
     <td><code>S3_DIRECTORY_SYNC_SECRET_ACCESS_KEY</code></td>
@@ -73,7 +73,7 @@ Parameters can either be passed in the command line as arguments or as environme
   <tr>
     <td><code>S3_DIRECTORY_SYNC_PROGRESS</code></td>
     <td>If set to <code>true</code> the CLI will display a progress bar. Might be buggy in CI which justifies this option.</td>
-    <td><code>true</code></td>
+    <td><code>false</code></td>
   </tr>
   <tr>
     <td><code>S3_DIRECTORY_SYNC_REMOTE_DIRECTORY</code></td>

--- a/src/helpers/arguments.test.js
+++ b/src/helpers/arguments.test.js
@@ -59,4 +59,13 @@ describe('convertOptionsFromArguments', () => {
     });
     expect(actual).toEqual(expected);
   });
+
+  it('should preserve boolean default values when also not set as flag params', () => {
+    const payload = {
+      S3_DIRECTORY_SYNC_DERIVE_CONTENT_TYPE: false,
+      S3_DIRECTORY_SYNC_PROGRESS: false
+    };
+    const actual = convertOptionsFromArguments(payload);
+    expect(actual).toEqual(payload);
+  });
 });


### PR DESCRIPTION
# Summary

Updates docs and tests as discovered in #9.